### PR TITLE
BUG: Fix health check and docker socket permission issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,8 +41,10 @@ COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/refresh-templates.sh /usr/local/bin/refresh-templates.sh
 RUN chmod +x /entrypoint.sh /usr/local/bin/refresh-templates.sh
 
-# Configure sudo for template refresh (allow guardian user to run refresh script as root)
-RUN echo "guardian ALL=(root) NOPASSWD: /usr/local/bin/refresh-templates.sh" > /etc/sudoers.d/guardian-templates \
+# Make refresh script setuid root so it can run with elevated privileges
+# Also configure sudo as backup method
+RUN chmod 4755 /usr/local/bin/refresh-templates.sh \
+    && echo "guardian ALL=(root) NOPASSWD: /usr/local/bin/refresh-templates.sh" > /etc/sudoers.d/guardian-templates \
     && chmod 440 /etc/sudoers.d/guardian-templates
 
 # Note: Start as root to allow entrypoint.sh to handle PUID/PGID switching

--- a/src/web_gui.py
+++ b/src/web_gui.py
@@ -5,6 +5,7 @@ FastAPI-based web interface for managing backups
 """
 
 import json
+import logging
 import os
 import zipfile
 from datetime import datetime
@@ -345,6 +346,25 @@ async def run_backup(output_dir: str):
             "containers": containers,
             "templates": templates,
         }
+
+        # Generate change log if available
+        change_log_content = None
+        if DOCKER_AVAILABLE:
+            try:
+                from config_diff import create_change_log
+
+                logging.info("Generating configuration change log...")
+                change_log_content = create_change_log(output_path, config)
+                if change_log_content:
+                    logging.info("Change log generated successfully")
+                else:
+                    logging.info("No change log generated (first backup or no changes)")
+            except ImportError:
+                logging.warning(
+                    "Change log functionality not available (config_diff module not found)"
+                )
+            except Exception as e:
+                logging.error(f"Error generating change log: {e}")
 
         # Write files
         import yaml

--- a/src/web_gui_dev.py
+++ b/src/web_gui_dev.py
@@ -5,6 +5,7 @@ Development version of Web GUI that handles Docker connection gracefully
 
 import asyncio
 import json
+import logging
 import os
 import zipfile
 from datetime import datetime
@@ -301,6 +302,25 @@ async def run_backup_mock(output_dir: str):
         output_path.mkdir(parents=True, exist_ok=True, mode=0o755)
         # Set permissions explicitly for Unraid compatibility
         os.chmod(output_path, 0o755)
+
+        # Generate change log if available
+        change_log_content = None
+        try:
+            from config_diff import create_change_log
+
+            logging.info("Generating configuration change log...")
+            config = {"system_info": MOCK_SYSTEM_INFO, "containers": MOCK_CONTAINERS}
+            change_log_content = create_change_log(output_path, config)
+            if change_log_content:
+                logging.info("Change log generated successfully")
+            else:
+                logging.info("No change log generated (first backup or no changes)")
+        except ImportError:
+            logging.warning(
+                "Change log functionality not available (config_diff module not found)"
+            )
+        except Exception as e:
+            logging.error(f"Error generating change log: {e}")
 
         # Mock files
         files = {


### PR DESCRIPTION
  Summary

  - Fixed Docker health check hardcoded socket path issue causing repeated container restarts
  - Resolved permission errors preventing subsequent backups after first run
  - Integrated change log functionality into web GUI to track configuration differences
  - Fixed git pre-push hook syntax error

  Issues Fixed

  - Health Check: Container was failing health checks due to hardcoded /var/run/docker.sock path
  - Permission Errors: Subsequent backups failed with "Permission denied: '/boot/config/plugins/dockerMan/templates-user'" after first successful run
  - Change Log Integration: create_change_log function was called but not properly integrated into web GUI
  - Made Docker socket path configurable via DOCKER_SOCK_PATH environment variable
  - Added fallback Docker client creation for custom socket paths
  - Improved error messages with troubleshooting tips
  - Added graceful handling of Docker connection failures during startup
  
  #24 
  #22 
  #21 