### PR TITLE
Align Docker health check with socket proxy flow

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,9 @@ services:
       - PGID=${PGID:-1000}         # Use your local group ID
       - TZ=America/New_York        # Adjust to your timezone
 
+      # Docker connection (uses socket proxy for security)
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
+
       # Backup configuration
       - SCHEDULE=0 2 * * 0         # Weekly Sunday at 2 AM
       - BACKUP_LOCATION=/output
@@ -56,6 +59,23 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  # Docker Socket Proxy for secure Docker access
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    container_name: docker-socket-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1    # Allow container inspection
+      - IMAGES=1        # Allow image inspection
+      - INFO=1          # Allow system info
+      - NETWORKS=1      # Allow network inspection
+      - VOLUMES=1       # Allow volume inspection
+      - POST=0          # Disable container creation/modification
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - unraid-guardian
 
 networks:
   unraid-guardian:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,9 @@ services:
       - PGID=100                   # users group
       - TZ=America/New_York        # Adjust to your timezone
 
+      # Docker connection (uses socket proxy for security)
+      - DOCKER_HOST=tcp://docker-socket-proxy:2375
+
       # Backup configuration
       - SCHEDULE=0 2 * * 0         # Weekly Sunday at 2 AM
       - BACKUP_LOCATION=/output
@@ -61,6 +64,23 @@ services:
       timeout: 10s
       retries: 3
       start_period: 40s
+
+  # Docker Socket Proxy for secure Docker access
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:latest
+    container_name: docker-socket-proxy
+    restart: unless-stopped
+    environment:
+      - CONTAINERS=1    # Allow container inspection
+      - IMAGES=1        # Allow image inspection
+      - INFO=1          # Allow system info
+      - NETWORKS=1      # Allow network inspection
+      - VOLUMES=1       # Allow volume inspection
+      - POST=0          # Disable container creation/modification
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - unraid-guardian
 
 networks:
   unraid-guardian:


### PR DESCRIPTION

DOCKER_HOST=tcp://docker-socket-proxy:2375 on the main
Service and spin up a tecnativa/docker-socket-proxy companion container so both dev and prod stacks route Docker API calls through the proxy.
  - src/health_check.py:11 mirrors the runtime client selection: prefer DOCKER_HOST, fall back to DOCKER_SOCK_PATH, then
    default to tcp://docker-socket-proxy:2375, with clearer success/failure logging.

  - src/unraid_config_guardian.py:28 uses the same priority order when creating the Docker client, ensuring CLI/GUI and
    the health check share identical connection logic and error reporting.