### PR TITLE
fix: MASK_PASSWORDS env var not working when set to false

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,6 @@ cryptography>=41.0.0
 # Web GUI
 fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
+starlette>=0.27,<0.53
 jinja2>=3.1.2
 python-multipart>=0.0.6

--- a/src/unraid_config_guardian.py
+++ b/src/unraid_config_guardian.py
@@ -25,7 +25,7 @@ from version import __version__
 # Removed unused imports: Any, Dict, List
 
 
-def get_containers():
+def get_containers(mask_passwords=True):
     """Get all Docker containers and their info."""
     try:
         # For local testing/CI, use direct Docker socket
@@ -126,14 +126,14 @@ def get_containers():
         except (KeyError, AttributeError) as e:
             logging.warning(f"Error getting volumes for {container.name}: {e}")
 
-        # Get environment (mask sensitive data)
+        # Get environment (mask sensitive data if configured)
         try:
             env_vars = container.attrs.get("Config", {}).get("Env") or []
             for env_var in env_vars:
                 if "=" in env_var:
                     key, value = env_var.split("=", 1)
-                    # Simple masking for common sensitive keys
-                    if any(
+                    # Only mask if mask_passwords is enabled
+                    if mask_passwords and any(
                         word in key.lower()
                         for word in ["password", "key", "token", "secret"]
                     ):
@@ -643,10 +643,25 @@ def main():
         "--output", default=os.getenv("OUTPUT_DIR", "/output"), help="Output directory"
     )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    parser.add_argument(
+        "--mask-passwords",
+        action="store_true",
+        default=os.getenv("MASK_PASSWORDS", "true").lower() in ("true", "1", "yes"),
+        help="Mask sensitive environment variables (default: true)",
+    )
+    parser.add_argument(
+        "--no-mask-passwords",
+        action="store_true",
+        help="Do not mask sensitive environment variables",
+    )
     args = parser.parse_args()
 
     setup_logging(args.debug, args.output)
     logger = logging.getLogger(__name__)
+
+    # Determine masking setting: --no-mask-passwords overrides --mask-passwords
+    mask_passwords = not args.no_mask_passwords and args.mask_passwords
+    logger.info(f"Password masking: {'enabled' if mask_passwords else 'disabled'}")
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True, mode=0o755)
@@ -658,7 +673,7 @@ def main():
     try:
         # Collect data
         logger.info("📦 Collecting container information...")
-        containers = get_containers()
+        containers = get_containers(mask_passwords=mask_passwords)
 
         logger.info("🖥️  Collecting system information...")
         system_info = get_system_info()

--- a/src/web_gui.py
+++ b/src/web_gui.py
@@ -91,7 +91,8 @@ def get_containers_safe():
     if not DOCKER_AVAILABLE:
         return MOCK_CONTAINERS
     try:
-        return get_containers()
+        mask_passwords = os.getenv("MASK_PASSWORDS", "true").lower() in ("true", "1", "yes")
+        return get_containers(mask_passwords=mask_passwords)
     except Exception as e:
         print(f"Docker not available, using mock data: {e}")
         return MOCK_CONTAINERS
@@ -489,9 +490,11 @@ def main():
     """Run the web server."""
     port = int(os.getenv("WEB_PORT", 7842))
     host = os.getenv("WEB_HOST", "0.0.0.0")
+    mask_passwords = os.getenv("MASK_PASSWORDS", "true").lower() in ("true", "1", "yes")
 
     print(f"🌐 Starting Unraid Config Guardian Web GUI on http://{host}:{port}")
     print("🔗 Access via: http://your-unraid-ip:7842")
+    print(f"🔒 MASK_PASSWORDS={'true' if mask_passwords else 'false'}")
 
     uvicorn.run("web_gui:app", host=host, port=port, reload=False, access_log=True)
 

--- a/src/web_gui_dev.py
+++ b/src/web_gui_dev.py
@@ -78,7 +78,8 @@ def get_containers_safe():
         # Try to import and use real Docker client
         from unraid_config_guardian import get_containers
 
-        return get_containers()
+        mask_passwords = os.getenv("MASK_PASSWORDS", "true").lower() in ("true", "1", "yes")
+        return get_containers(mask_passwords=mask_passwords)
     except Exception as e:
         print(f"Docker not available, using mock data: {e}")
         return MOCK_CONTAINERS
@@ -588,10 +589,12 @@ def main():
     """Run the web server."""
     port = int(os.getenv("WEB_PORT", 7842))
     host = os.getenv("WEB_HOST", "0.0.0.0")
+    mask_passwords = os.getenv("MASK_PASSWORDS", "true").lower() in ("true", "1", "yes")
 
     print("🌐 Starting Unraid Config Guardian Web GUI (Development Mode)")
     print(f"🔗 Access via: http://localhost:{port}")
     print("📋 Note: Using mock data for development")
+    print(f"🔒 MASK_PASSWORDS={'true' if mask_passwords else 'false'}")
 
     uvicorn.run("web_gui_dev:app", host=host, port=port, reload=False, access_log=True)
 

--- a/tests/test_unraid_config_guardian.py
+++ b/tests/test_unraid_config_guardian.py
@@ -50,6 +50,38 @@ def test_get_containers():
         assert container["environment"]["SECRET_PASSWORD"] == "***MASKED***"
 
 
+def test_get_containers_no_mask():
+    """Test container information extraction without password masking."""
+    with patch("docker.from_env") as mock_docker:
+        # Mock container
+        mock_container = Mock()
+        mock_container.name = "test-container"
+        mock_container.image.tags = ["nginx:latest"]
+        mock_container.status = "running"
+        mock_container.attrs = {
+            "NetworkSettings": {"Ports": {"80/tcp": [{"HostPort": "8080"}]}},
+            "Mounts": [
+                {
+                    "Type": "bind",
+                    "Source": "/host/path",
+                    "Destination": "/container/path",
+                }
+            ],
+            "Config": {"Env": ["TEST_VAR=test_value", "SECRET_PASSWORD=hidden"]},
+        }
+
+        mock_client = Mock()
+        mock_client.containers.list.return_value = [mock_container]
+        mock_docker.return_value = mock_client
+
+        containers = guardian.get_containers(mask_passwords=False)
+
+        assert len(containers) == 1
+        container = containers[0]
+        assert container["environment"]["SECRET_PASSWORD"] == "hidden"
+        assert container["environment"]["TEST_VAR"] == "test_value"
+
+
 def test_generate_compose():
     """Test docker-compose generation."""
     containers = [


### PR DESCRIPTION
## Summary
The `MASK_PASSWORDS` environment variable was written to `config.yml` but never actually read by the Python code. Password masking was hardcoded and always active regardless of the setting.

## Changes
- **`src/unraid_config_guardian.py`**
  - Added `mask_passwords` parameter to `get_containers()`
  - Made env variable masking conditional on the parameter
  - Added `--mask-passwords` and `--no-mask-passwords` CLI flags
  - Reads `MASK_PASSWORDS` from environment in `main()` (defaults to true)

- **`src/web_gui.py` / `src/web_gui_dev.py`**
  - `get_containers_safe()` now reads `MASK_PASSWORDS` from env and passes it through
  - Prints `MASK_PASSWORDS` value on startup for visibility

- **`requirements.txt`**
  - Pinned `starlette>=0.27,<0.53` to prevent breaking changes in the `TemplateResponse` API

- **`tests/test_unraid_config_guardian.py`**
  - Added `test_get_containers_no_mask` to verify masking works correctly when disabled

## Testing
Set `MASK_PASSWORDS=false` in your docker-compose or run with `--no-mask-passwords` flag. Passwords, tokens, keys, and secrets will now appear unmasked in `unraid-config.json` and `docker-compose.yml`.