### PR TITLE
Fix #42: Mask VPN/SOCKS credentials for binhex-qbittorrentvpn container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,14 @@ docker-compose.override.yml
 *secret*
 *token*
 *api_key*
+# ================================
+#JSK Added 7/24/26 for container binhex-qbittorrentvpn
+# ================================
+*VPN_PASS* 
+*VPN_USER*
+*SOCKS_USER* 
+*SOCKS_PASS*
+# ================================
 
 # But allow example files
 !*.example

--- a/src/unraid_config_guardian.py
+++ b/src/unraid_config_guardian.py
@@ -11,6 +11,7 @@ import json
 import logging
 import os
 import subprocess
+import xml.etree.ElementTree as ET
 import zipfile
 from datetime import datetime
 from pathlib import Path
@@ -23,6 +24,20 @@ from config_diff import create_change_log
 from version import __version__
 
 # Removed unused imports: Any, Dict, List
+
+# Keywords used to detect sensitive env vars / template config values that
+# should be masked before writing to backup output. Added vpn_pass/vpn_user/
+# socks_user/socks_pass for binhex-qbittorrentvpn.
+SENSITIVE_ENV_KEYWORDS = [
+    "password",
+    "key",
+    "token",
+    "secret",
+    "vpn_pass",
+    "vpn_user",
+    "socks_user",
+    "socks_pass",
+]
 
 
 def get_containers():
@@ -133,19 +148,7 @@ def get_containers():
                 if "=" in env_var:
                     key, value = env_var.split("=", 1)
                     # Simple masking for common sensitive keys
-                    # Added vpn_pass/vpn_user/socks_user/socks_pass for
-                    # binhex-qbittorrentvpn
-                    sensitive_words = [
-                        "password",
-                        "key",
-                        "token",
-                        "secret",
-                        "vpn_pass",
-                        "vpn_user",
-                        "socks_user",
-                        "socks_pass",
-                    ]
-                    if any(word in key.lower() for word in sensitive_words):
+                    if any(word in key.lower() for word in SENSITIVE_ENV_KEYWORDS):
                         value = "***MASKED***"
                     info["environment"][key] = value
         except (KeyError, AttributeError) as e:
@@ -405,6 +408,27 @@ def get_container_templates():
     return templates
 
 
+def mask_template_xml(xml_path: Path) -> bytes:
+    """Mask sensitive <Config> values in an Unraid template XML file.
+
+    Unraid stores each container's configured variables (including
+    credentials like VPN_USER/VPN_PASS) as plain-text <Config> element
+    text in these template files, independent of the live Docker
+    container inspection used by get_containers().
+    """
+    tree = ET.parse(xml_path)
+    root = tree.getroot()
+
+    for config in root.findall("Config"):
+        name = (config.get("Name") or "").lower()
+        target = (config.get("Target") or "").lower()
+        if any(word in name or word in target for word in SENSITIVE_ENV_KEYWORDS):
+            config.text = "***MASKED***"
+
+    xml_bytes: bytes = ET.tostring(root, encoding="utf-8", xml_declaration=True)
+    return xml_bytes
+
+
 def create_templates_zip(templates, output_dir):
     """Create a zip file containing all XML templates."""
     if not templates:
@@ -428,7 +452,15 @@ def create_templates_zip(templates, output_dir):
 
                 if template_path.exists():
                     try:
-                        zipf.write(template_path, template["name"])
+                        try:
+                            masked_xml = mask_template_xml(template_path)
+                            zipf.writestr(template["name"], masked_xml)
+                        except ET.ParseError as parse_error:
+                            logging.warning(
+                                f"Could not parse {template['name']} as XML, "
+                                f"copying without masking: {parse_error}"
+                            )
+                            zipf.write(template_path, template["name"])
                         templates_added += 1
                         logging.info(f"Added {template['name']} to zip")
                     except Exception as template_error:

--- a/src/unraid_config_guardian.py
+++ b/src/unraid_config_guardian.py
@@ -133,10 +133,19 @@ def get_containers():
                 if "=" in env_var:
                     key, value = env_var.split("=", 1)
                     # Simple masking for common sensitive keys
-                    if any(
-                        word in key.lower()
-                        for word in ["password", "key", "token", "secret"]
-                    ):
+                    # Added vpn_pass/vpn_user/socks_user/socks_pass for
+                    # binhex-qbittorrentvpn
+                    sensitive_words = [
+                        "password",
+                        "key",
+                        "token",
+                        "secret",
+                        "vpn_pass",
+                        "vpn_user",
+                        "socks_user",
+                        "socks_pass",
+                    ]
+                    if any(word in key.lower() for word in sensitive_words):
                         value = "***MASKED***"
                     info["environment"][key] = value
         except (KeyError, AttributeError) as e:

--- a/tests/test_unraid_config_guardian.py
+++ b/tests/test_unraid_config_guardian.py
@@ -97,6 +97,36 @@ def test_get_containers_masks_sensitive_env_vars():
         assert env["TEST_VAR"] == "not_sensitive"
 
 
+def test_mask_template_xml(tmp_path):
+    """Test that sensitive Config values in Unraid template XML are masked."""
+    import xml.etree.ElementTree as ET
+
+    xml_content = """<?xml version="1.0"?>
+<Container version="2">
+  <Name>binhex-qbittorrentvpn</Name>
+  <Config Name="VPN_USER" Target="VPN_USER" Type="Variable">myvpnuser</Config>
+  <Config Name="VPN_PASS" Target="VPN_PASS" Type="Variable">myvpnpass</Config>
+  <Config Name="SOCKS_USER" Target="SOCKS_USER" Type="Variable">mysocksuser</Config>
+  <Config Name="SOCKS_PASS" Target="SOCKS_PASS" Type="Variable">mysockspass</Config>
+  <Config Name="WebUI Port" Target="8080" Type="Port">8080</Config>
+</Container>
+"""
+    template_path = tmp_path / "binhex-qbittorrentvpn.xml"
+    template_path.write_text(xml_content, encoding="utf-8")
+
+    masked_xml = guardian.mask_template_xml(template_path)
+    root = ET.fromstring(masked_xml)
+    configs = {c.get("Name"): c.text for c in root.findall("Config")}
+
+    assert configs["VPN_USER"] == "***MASKED***"
+    assert configs["VPN_PASS"] == "***MASKED***"
+    assert configs["SOCKS_USER"] == "***MASKED***"
+    assert configs["SOCKS_PASS"] == "***MASKED***"
+
+    # Sanity check: non-sensitive config passes through unmasked
+    assert configs["WebUI Port"] == "8080"
+
+
 def test_generate_compose():
     """Test docker-compose generation."""
     containers = [

--- a/tests/test_unraid_config_guardian.py
+++ b/tests/test_unraid_config_guardian.py
@@ -50,6 +50,53 @@ def test_get_containers():
         assert container["environment"]["SECRET_PASSWORD"] == "***MASKED***"
 
 
+def test_get_containers_masks_sensitive_env_vars():
+    """Test that each sensitive keyword triggers masking of its env var value."""
+    with patch("docker.from_env") as mock_docker:
+        mock_container = Mock()
+        mock_container.name = "test-container"
+        mock_container.image.tags = ["nginx:latest"]
+        mock_container.status = "running"
+        mock_container.attrs = {
+            "NetworkSettings": {},
+            "Mounts": [],
+            "Config": {
+                "Env": [
+                    "DB_PASSWORD=hunter2",
+                    "API_KEY=abc123",
+                    "AUTH_TOKEN=xyz789",
+                    "APP_SECRET=shh",
+                    "VPN_PASS=vpnpass123",
+                    "VPN_USER=vpnuser123",
+                    "SOCKS_USER=socksuser123",
+                    "SOCKS_PASS=sockspass123",
+                    "TEST_VAR=not_sensitive",
+                ]
+            },
+        }
+
+        mock_client = Mock()
+        mock_client.containers.list.return_value = [mock_container]
+        mock_docker.return_value = mock_client
+
+        containers = guardian.get_containers()
+
+        assert len(containers) == 1
+        env = containers[0]["environment"]
+
+        assert env["DB_PASSWORD"] == "***MASKED***"
+        assert env["API_KEY"] == "***MASKED***"
+        assert env["AUTH_TOKEN"] == "***MASKED***"
+        assert env["APP_SECRET"] == "***MASKED***"
+        assert env["VPN_PASS"] == "***MASKED***"
+        assert env["VPN_USER"] == "***MASKED***"
+        assert env["SOCKS_USER"] == "***MASKED***"
+        assert env["SOCKS_PASS"] == "***MASKED***"
+
+        # Sanity check: non-sensitive vars pass through unmasked
+        assert env["TEST_VAR"] == "not_sensitive"
+
+
 def test_generate_compose():
     """Test docker-compose generation."""
     containers = [


### PR DESCRIPTION
binhex-qbittorrentvpn uses non-standard env var names (VPN_PASS, VPN_USER, SOCKS_USER, SOCKS_PASS) that the existing masking keyword list (password, key, token, secret) didn't cover, so these credentials were written to backups in plain text. I added the four keywords to the masking list to stop plain text user/passwords from happening.

Also added a new test case to confirm these changes were working. 

## Changes

* `src/unraid_config_guardian.py`
   * Added `vpn_pass`, `vpn_user`, `socks_user`, `socks_pass` to the sensitive-keyword list used for env var masking in `get_containers()` — binhex-qbittorrentvpn uses these instead of the standard `password`/`key`/`token`/`secret` names, so it's VPN/SOCKS credentials were being written to backups in plain text

* `.gitignore`
   * Added patterns to exclude local files named after `VPN_PASS`, `VPN_USER`, `SOCKS_USER`, `SOCKS_PASS`
* `tests/test_unraid_config_guardian.py`
   * Added `test_get_containers_masks_sensitive_env_vars` to verify all 8 sensitive keywords (`password`, `key`, `token`, `secret`, `vpn_pass`, `vpn_user`, `socks_user`, `socks_pass`) get masked, plus a check that non-sensitive vars pass through unmasked

Fixes #42

## Testing
Run a backup against a container with `VPN_PASS`, `VPN_USER`, `SOCKS_USER`, or `SOCKS_PASS` set in its environment (e.g. binhex-qbittorrentvpn). Check the generated `unraid-config.json` / `docker-compose.yml` — these values now appear as `***MASKED***` instead of plain text.

`pytest tests/`, `black --check`, `flake8`, and `mypy` all pass locally, matching CI.